### PR TITLE
check widget is still mounted when running Future.delayed()

### DIFF
--- a/lib/jumping_dot.dart
+++ b/lib/jumping_dot.dart
@@ -118,7 +118,9 @@ class _JumpingDotsState extends State<JumpingDots>
               _animationControllers![0].forward();
           } else {
             Future.delayed(Duration(milliseconds: widget.delay), () {
-              _animationControllers![0].forward();
+              if(mounted) {
+                _animationControllers![0].forward();
+              }
             });
           }
         }


### PR DESCRIPTION
- prevent starting the animation after dispose() has been called; this will happen when the widget has been dispose()-ed _before_ the delay time has elapsed
- update readme.md